### PR TITLE
feat(mcp): harden security, improve reliability and observability

### DIFF
--- a/backend/src/api/integrations_mcp.py
+++ b/backend/src/api/integrations_mcp.py
@@ -42,6 +42,24 @@ router = APIRouter(prefix="/integrations/mcp", tags=["integrations-mcp"])
 # Simple in-memory store for OAuth tokens (server_id -> token)
 _OAUTH_TOKENS: Dict[str, Dict[str, str]] = {}
 
+from pathlib import Path
+
+def _validate_stdio_command(command: str) -> bool:
+    allowlist = os.getenv("MCP_STDIO_ALLOWLIST")
+    if not allowlist:
+        return True
+    
+    if allowlist.strip() == "*":
+        return True
+        
+    allowed = [c.strip() for c in allowlist.split(",")]
+    return command in allowed
+
+def _get_runner_script_path() -> Path:
+    # Resolve relative to this file: backend/src/api/integrations_mcp.py
+    # We want: backend/scripts/mcp_stdio_runner.py
+    return Path(__file__).resolve().parents[2] / "scripts" / "mcp_stdio_runner.py"
+
 def _is_admin(headers: Dict[str, str]) -> bool:
     # Simple admin protection: require header X-Admin-Token matching env ADMIN_TOKEN
     admin_token = os.getenv("ADMIN_TOKEN")
@@ -152,14 +170,18 @@ async def test_connection(body: Dict[str, Any] = Body(...)):
             command = body.get("command")
             if not command:
                 return {"ok": False, "error": "Missing command for stdio"}
+            
+            if not _validate_stdio_command(command):
+                return {"ok": False, "error": f"Command '{command}' is not in MCP_STDIO_ALLOWLIST"}
+
             # Use an external runner process to perform stdio startup and
             # list tools. Running the MCP stdio SDK in a separate process
             # avoids mixing anyio/asyncio taskgroups with the FastAPI event
             # loop and prevents the cancel-scope errors observed when the
             # SDK runs inside the webserver process.
-            runner_script = os.path.join(os.getcwd(), 'scripts', 'mcp_stdio_runner.py')
-            if not os.path.exists(runner_script):
-                return {"ok": False, "error": f"runner script not found: {runner_script}"}
+            runner_script_path = _get_runner_script_path()
+            if not runner_script_path.exists():
+                return {"ok": False, "error": f"runner script not found: {runner_script_path}"}
             payload = {
                 "command": command,
                 "args": body.get("args") or [],
@@ -168,7 +190,7 @@ async def test_connection(body: Dict[str, Any] = Body(...)):
             }
             try:
                 # Invoke the runner and capture JSON output
-                proc = subprocess.run([sys.executable, runner_script], input=json.dumps(payload).encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=_STDIO_START_TIMEOUT)
+                proc = subprocess.run([sys.executable, str(runner_script_path)], input=json.dumps(payload).encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=_STDIO_START_TIMEOUT)
                 if proc.returncode != 0:
                     # include stderr for diagnostics
                     stderr = proc.stderr.decode('utf-8', errors='replace')
@@ -335,19 +357,9 @@ async def init_model(background_tasks: BackgroundTasks, body: Dict[str, Any] = B
             _metrics["init_failed_count"] = _metrics.get("init_failed_count", 0) + 1
             logger.exception("Background model init failed: %s", e)
 
-    # Schedule the async init task in the current event loop
-    try:
-        background_tasks.add_task(asyncio.create_task, _init_task_async())
-    except Exception:
-        # Fallback: run synchronous wrapper if scheduling fails
-        def _init_task():
-            try:
-                import asyncio as _a
-                _a.run(_init_task_async())
-            except Exception:
-                logger.exception("Fallback background init failed")
-
-        background_tasks.add_task(_init_task)
+    # Schedule the async init task
+    background_tasks.add_task(_init_task_async)
+    
     logger.info("Background model init started for model=%s", model)
     return {"ok": True, "started": True}
 

--- a/backend/src/services/mcp/clients/sse_client.py
+++ b/backend/src/services/mcp/clients/sse_client.py
@@ -4,14 +4,20 @@ SSE (Streamable HTTP) MCP connection using the official MCP SDK.
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+import asyncio
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
 
 
 class SseMcpConnection:
     """SSE-based MCP client connection."""
 
-    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None) -> None:
+    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None, timeout: float = 60.0) -> None:
         self._url = url
         self._headers = headers or {}
+        self._timeout = timeout
         self._session = None
         self._client = None
         self._context = None
@@ -22,18 +28,35 @@ class SseMcpConnection:
             from mcp.client.session import ClientSession
             from mcp.client.streamable_http import streamablehttp_client
 
+            logger.info(f"Connecting to SSE MCP server: {self._url} (timeout={self._timeout}s)")
             # Start SSE client (streamable http)
+            # streamablehttp_client likely uses aiohttp or httpx underneath.
+            # We enforce timeout on the connection phase.
             self._context = streamablehttp_client(self._url, headers=self._headers)
+            
             # streamablehttp_client yields (read, write, worker)
-            read, write, _ = await self._context.__aenter__()
+            read, write, _ = await asyncio.wait_for(self._context.__aenter__(), timeout=self._timeout)
             
             self._session = ClientSession(read, write)
-            await self._session.initialize()
+            await asyncio.wait_for(self._session.initialize(), timeout=self._timeout)
             self._client = self._session
+            logger.info(f"Connected to SSE MCP server: {self._url}")
+        except asyncio.TimeoutError:
+            self._session = None
+            self._client = None
+            logger.error(f"Timeout connecting to SSE MCP server: {self._url}")
+            raise RuntimeError(f"Timeout connecting to {self._url} after {self._timeout}s")
         except Exception as e:
             self._session = None
             self._client = None
-            raise RuntimeError(f"Failed to start SSE MCP connection: {e}") from e
+            # Log full traceback for debugging
+            logger.error(f"Failed to start SSE MCP connection to {self._url}: {e}")
+            logger.debug(traceback.format_exc())
+            # Try to extract more info if it's an HTTP error (generic check as we don't import aiohttp)
+            msg = str(e)
+            if hasattr(e, 'status'):
+                msg = f"HTTP {e.status}: {msg}" # type: ignore
+            raise RuntimeError(f"Failed to start SSE MCP connection: {msg}") from e
 
     async def stop(self) -> None:
         """Stop the MCP server connection."""

--- a/backend/src/services/mcp/clients/stdio_client.py
+++ b/backend/src/services/mcp/clients/stdio_client.py
@@ -11,8 +11,112 @@ import os
 import time
 import subprocess
 import threading
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class _StdioMonkeyPatch:
+    def __init__(self):
+        self.logs_dir = os.path.join(os.getcwd(), 'logs')
+        try:
+            os.makedirs(self.logs_dir, exist_ok=True)
+        except Exception:
+            pass
+        ts = int(time.time())
+        self.diag_log = os.path.join(self.logs_dir, f"mcp_stdio_diag_{ts}.log")
+        self.child_log = os.path.join(self.logs_dir, f"mcp_stdio_child_{ts}.log")
+        
+        self.orig_create = asyncio.create_subprocess_exec
+        self.orig_subproc_create = getattr(asyncio.subprocess, 'create_subprocess_exec', None)
+        self.orig_popen = subprocess.Popen
+
+    def __enter__(self):
+        asyncio.create_subprocess_exec = self._wrapped_create_subprocess_exec
+        if self.orig_subproc_create:
+            asyncio.subprocess.create_subprocess_exec = self._wrapped_create_subprocess_exec
+        subprocess.Popen = self._wrapped_popen
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        asyncio.create_subprocess_exec = self.orig_create
+        if self.orig_subproc_create:
+            asyncio.subprocess.create_subprocess_exec = self.orig_subproc_create
+        subprocess.Popen = self.orig_popen
+
+    async def _wrapped_create_subprocess_exec(self, *p, **kw):
+        kw['stdout'] = asyncio.subprocess.PIPE
+        kw['stderr'] = asyncio.subprocess.PIPE
+        try:
+            with open(self.diag_log, 'a', encoding='utf-8') as f:
+                try:
+                    f.write(f"PROC_ATTEMPT args={p} kw={{{', '.join([f'{k}={v}' for k,v in kw.items()])}}}\n")
+                except Exception:
+                    f.write("PROC_ATTEMPT args=...\n")
+                f.flush()
+        except Exception:
+            pass
+
+        try:
+            proc = await self.orig_create(*p, **kw)
+        except Exception as e:
+            try:
+                with open(self.diag_log, 'a', encoding='utf-8') as f:
+                    f.write(f"PROC_CREATE_FAILED: {repr(e)}\n")
+                    f.flush()
+            except Exception:
+                pass
+            raise
+            
+        try:
+            with open(self.diag_log, 'a', encoding='utf-8') as f:
+                f.write(f"PROC_START pid={getattr(proc, 'pid', None)} args={p} kw={{{', '.join([f'{k}={v}' for k,v in kw.items()])}}}\n")
+                f.flush()
+        except Exception:
+            pass
+
+        async def _wait_and_log(pobj, path):
+            try:
+                code = await pobj.wait()
+                with open(path, 'a', encoding='utf-8') as f:
+                    f.write(f"PROC_EXIT pid={getattr(pobj, 'pid', None)} code={code}\n")
+            except Exception:
+                pass
+
+        try:
+            asyncio.create_task(_wait_and_log(proc, self.diag_log))
+        except Exception:
+            pass
+
+        return proc
+
+    def _wrapped_popen(self, *popen_args, **popen_kwargs):
+        popen_kwargs.setdefault('stdout', subprocess.PIPE)
+        popen_kwargs.setdefault('stderr', subprocess.PIPE)
+        proc = self.orig_popen(*popen_args, **popen_kwargs)
+
+        def _drain_stream(stream, path):
+            try:
+                with open(path, 'ab') as f:
+                    while True:
+                        data = stream.read(1024)
+                        if not data:
+                            break
+                        f.write(data)
+                        f.flush()
+            except Exception:
+                pass
+
+        try:
+            if proc.stdout is not None:
+                t = threading.Thread(target=_drain_stream, args=(proc.stdout, self.child_log), daemon=True)
+                t.start()
+            if proc.stderr is not None:
+                t2 = threading.Thread(target=_drain_stream, args=(proc.stderr, self.child_log), daemon=True)
+                t2.start()
+        except Exception:
+            pass
+        return proc
 
 
 class StdioMcpConnection:
@@ -37,39 +141,22 @@ class StdioMcpConnection:
                 import json
                 import sys
 
-                # Find backend dir by walking upward until we hit a folder
-                # named 'backend'. This mirrors earlier backend discovery.
-                backend_dir = None
-                try:
-                    cur = os.path.abspath(__file__)
-                    cur_dir = os.path.dirname(cur)
-                    while True:
-                        if os.path.basename(cur_dir) == 'backend':
-                            backend_dir = cur_dir
-                            break
-                        parent = os.path.dirname(cur_dir)
-                        if parent == cur_dir or not parent:
-                            break
-                        cur_dir = parent
-                except Exception:
-                    backend_dir = None
-                if not backend_dir:
-                    backend_dir = os.getcwd()
-
-                runner_script = os.path.join(backend_dir, 'scripts', 'mcp_stdio_runner.py')
+                # Resolve relative to this file
+                backend_dir = Path(__file__).resolve().parents[4]
+                runner_script = backend_dir / 'scripts' / 'mcp_stdio_runner.py'
 
                 payload = {
                     'command': self._command,
                     'args': self._args or [],
                     'env': self._env or {},
-                    'cwd': backend_dir,
+                    'cwd': str(backend_dir),
                     'timeout': int(os.environ.get('MCP_STDIO_START_TIMEOUT', '60')),
                     'attempts': int(os.environ.get('MCP_STDIO_RUNNER_ATTEMPTS', '3')),
                 }
 
                 def _run_runner():
                     try:
-                        p = subprocess.run([sys.executable, runner_script], input=json.dumps(payload), text=True, capture_output=True)
+                        p = subprocess.run([sys.executable, str(runner_script)], input=json.dumps(payload), text=True, capture_output=True)
                         out = p.stdout.strip()
                         if not out:
                             raise RuntimeError(f"Runner produced no output, rc={p.returncode}, err={p.stderr}")
@@ -103,122 +190,7 @@ class StdioMcpConnection:
             # To aid debugging when the SDK spawns the child process via
             # asyncio.create_subprocess_exec, temporarily monkey-patch that
             # function so we can capture the child's stdout/stderr to a file.
-            orig_create = asyncio.create_subprocess_exec
-            orig_subproc_create = None
-            if hasattr(asyncio, 'subprocess') and hasattr(asyncio.subprocess, 'create_subprocess_exec'):
-                orig_subproc_create = asyncio.subprocess.create_subprocess_exec
-            diag_log = None
-            try:
-                # Ensure logs directory exists and create two files:
-                # - diag_log: general spawn/diagnostic entries (mcp_stdio_diag_<ts>.log)
-                # - child_log: captured child stdout/stderr (mcp_stdio_child_<ts>.log)
-                logs_dir = os.path.join(os.getcwd(), 'logs')
-                try:
-                    os.makedirs(logs_dir, exist_ok=True)
-                except Exception:
-                    pass
-                diag_log = os.path.join(logs_dir, f"mcp_stdio_diag_{int(time.time())}.log")
-                child_log = os.path.join(logs_dir, f"mcp_stdio_child_{int(time.time())}.log")
-
-                async def _wrapped_create_subprocess_exec(*p, **kw):
-                    # Force pipes so we can capture diagnostic output. The SDK
-                    # sometimes passes explicit stdout/stderr values (eg
-                    # sys.stderr) which prevents setdefault from taking effect.
-                    # For reliable diagnostics we override and force PIPEs here
-                    # (this is only for diagnostics; we avoid draining these
-                    # streams concurrently to prevent read() races with the
-                    # SDK's anyio readers).
-                    kw['stdout'] = asyncio.subprocess.PIPE
-                    kw['stderr'] = asyncio.subprocess.PIPE
-                    # Log the subprocess spawn attempt (args/kw) even if
-                    # creation fails or is cancelled, so we can debug
-                    # platform-specific spawn failures.
-                    try:
-                        with open(diag_log, 'a', encoding='utf-8') as f:
-                            try:
-                                f.write(f"PROC_ATTEMPT args={p} kw={{{', '.join([f'{k}={v}' for k,v in kw.items()])}}}\n")
-                            except Exception:
-                                f.write("PROC_ATTEMPT args=...\n")
-                            f.flush()
-                    except Exception:
-                        pass
-
-                    try:
-                        proc = await orig_create(*p, **kw)
-                    except Exception as e:
-                        try:
-                            with open(diag_log, 'a', encoding='utf-8') as f:
-                                f.write(f"PROC_CREATE_FAILED: {repr(e)}\n")
-                                f.flush()
-                        except Exception:
-                            pass
-                        raise
-                    # Log the spawned subprocess pid and args to the diag log
-                    try:
-                        with open(diag_log, 'a', encoding='utf-8') as f:
-                            f.write(f"PROC_START pid={getattr(proc, 'pid', None)} args={p} kw={{{', '.join([f'{k}={v}' for k,v in kw.items()])}}}\n")
-                            f.flush()
-                    except Exception:
-                        pass
-
-                    # Monitor subprocess exit in background (non-draining)
-                    async def _wait_and_log(pobj, path):
-                        try:
-                            code = await pobj.wait()
-                            with open(path, 'a', encoding='utf-8') as f:
-                                f.write(f"PROC_EXIT pid={getattr(pobj, 'pid', None)} code={code}\n")
-                        except Exception:
-                            pass
-
-                    try:
-                        asyncio.create_task(_wait_and_log(proc, diag_log))
-                    except Exception:
-                        pass
-
-                    return proc
-
-                asyncio.create_subprocess_exec = _wrapped_create_subprocess_exec
-                try:
-                    if orig_subproc_create is not None:
-                        asyncio.subprocess.create_subprocess_exec = _wrapped_create_subprocess_exec
-                except Exception:
-                    pass
-                # Also monkey-patch subprocess.Popen to capture outputs if the
-                # SDK uses synchronous spawn. This wrapper will pipe stdout/stderr
-                # to the same diag_log file.
-                orig_popen = subprocess.Popen
-
-                def _wrapped_popen(*popen_args, **popen_kwargs):
-                    popen_kwargs.setdefault('stdout', subprocess.PIPE)
-                    popen_kwargs.setdefault('stderr', subprocess.PIPE)
-                    proc = orig_popen(*popen_args, **popen_kwargs)
-
-                    def _drain_stream(stream, path):
-                        try:
-                            with open(path, 'ab') as f:
-                                while True:
-                                    data = stream.read(1024)
-                                    if not data:
-                                        break
-                                    f.write(data)
-                                    f.flush()
-                        except Exception:
-                            pass
-
-                    try:
-                        # Drain child stdout/stderr into dedicated child_log
-                        if proc.stdout is not None:
-                            t = threading.Thread(target=_drain_stream, args=(proc.stdout, child_log), daemon=True)
-                            t.start()
-                        if proc.stderr is not None:
-                            t2 = threading.Thread(target=_drain_stream, args=(proc.stderr, child_log), daemon=True)
-                            t2.start()
-                    except Exception:
-                        pass
-                    return proc
-
-                subprocess.Popen = _wrapped_popen
-
+            with _StdioMonkeyPatch() as patcher:
                 # Normalize args to avoid duplicated `backend/backend` paths.
                 # Many test helpers pass paths like `backend/scripts/...` which
                 # when combined with an explicit `backend` cwd can produce
@@ -265,32 +237,12 @@ class StdioMcpConnection:
                         proxy_port = listener.getsockname()[1]
 
                         # Compute the absolute `backend` directory based on this
-                        # module's file location. This is more robust than relying
-                        # on process cwd, and avoids duplicated `.../backend/backend`
-                        # paths introduced by various start methods.
-                        backend_dir = None
-                        try:
-                            # Walk upward from this file to find a directory
-                            # named 'backend' and use its absolute path. This
-                            # is robust on Windows and avoids mixing drive
-                            # letters or path separator reconstruction issues.
-                            cur = os.path.abspath(__file__)
-                            cur_dir = os.path.dirname(cur)
-                            while True:
-                                if os.path.basename(cur_dir) == 'backend':
-                                    backend_dir = cur_dir
-                                    break
-                                parent = os.path.dirname(cur_dir)
-                                if parent == cur_dir or not parent:
-                                    break
-                                cur_dir = parent
-                        except Exception:
-                            backend_dir = None
-                        if not backend_dir:
-                            backend_dir = orig_cwd
+                        # module's file location.
+                        backend_dir_path = Path(__file__).resolve().parents[4]
+                        backend_dir = str(backend_dir_path)
 
                         # Build wrapper server params (SDK will spawn this wrapper)
-                        wrapper_script = os.path.join(backend_dir, 'scripts', 'mcp_stdio_wrapper.py')
+                        wrapper_script = str(backend_dir_path / 'scripts' / 'mcp_stdio_wrapper.py')
                         try:
                             logger.info("Computed backend_dir=%s wrapper_script=%s orig_cwd=%s", backend_dir, wrapper_script, orig_cwd)
                         except Exception:
@@ -310,7 +262,7 @@ class StdioMcpConnection:
                         # asyncio and anyio accept calls in the same event loop.
                         # Write a guaranteed pre-spawn diag entry for the wrapper
                         try:
-                            with open(diag_log, 'a', encoding='utf-8') as f:
+                            with open(patcher.diag_log, 'a', encoding='utf-8') as f:
                                 f.write("PRE_SPAWN wrapper command=%s args=%s cwd=%s env_keys=%s backend_dir=%s proxy_port=%s\n" % (
                                     wrapper_cmd, wrapper_args, orig_cwd, list(wrapper_env.keys()), backend_dir, proxy_port
                                 ))
@@ -381,26 +333,28 @@ class StdioMcpConnection:
                         # Spawn the real child process whose stdio we will bridge
                         # Log child pre-spawn details so we have exact args/cwd/env
                         try:
-                            with open(diag_log, 'a', encoding='utf-8') as f:
+                            with open(patcher.diag_log, 'a', encoding='utf-8') as f:
                                 f.write("PRE_SPAWN child command=%s args=%s cwd=%s backend_dir=%s\n" % (
                                     self._command, final_args, orig_cwd, backend_dir
                                 ))
                                 f.flush()
                         except Exception:
                             pass
+                        
+                        # Use ORIG POPEN to avoid double-draining by the patcher
                         try:
-                            child_proc = subprocess.Popen([self._command] + final_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=backend_dir)
+                            child_proc = patcher.orig_popen([self._command] + final_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=backend_dir)
                         except Exception:
-                            # fallback: spawn with original normalized args
+                            # fallback
                             try:
-                                with open(diag_log, 'a', encoding='utf-8') as f:
+                                with open(patcher.diag_log, 'a', encoding='utf-8') as f:
                                     f.write("PRE_SPAWN child FALLBACK command=%s args=%s cwd=%s\n" % (
                                         self._command, normalized_args, orig_cwd
                                     ))
                                     f.flush()
                             except Exception:
                                 pass
-                            child_proc = subprocess.Popen([self._command] + normalized_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=backend_dir)
+                            child_proc = patcher.orig_popen([self._command] + normalized_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=backend_dir)
 
                         # Start threads to forward between child pipes and the accepted socket
                         def _pipe_to_sock(src, sock):
@@ -451,7 +405,7 @@ class StdioMcpConnection:
                         try:
                             t_out = threading.Thread(target=_pipe_to_sock, args=(child_proc.stdout, client_sock), daemon=True)
                             t_in = threading.Thread(target=_sock_to_pipe, args=(client_sock, child_proc.stdin), daemon=True)
-                            t_err = threading.Thread(target=_drain_stderr, args=(child_proc.stderr, diag_log), daemon=True)
+                            t_err = threading.Thread(target=_drain_stderr, args=(child_proc.stderr, patcher.diag_log), daemon=True)
                             t_out.start()
                             t_in.start()
                             t_err.start()
@@ -461,7 +415,7 @@ class StdioMcpConnection:
                         # Default flow: let SDK spawn the child on stdio
                         # Write a pre-spawn diag entry for the SDK spawn attempt
                         try:
-                            with open(diag_log, 'a', encoding='utf-8') as f:
+                            with open(patcher.diag_log, 'a', encoding='utf-8') as f:
                                 f.write("PRE_SPAWN sdk_spawn command=%s args=%s cwd=%s env_keys=%s\n" % (
                                     self._command, normalized_args, orig_cwd, list((self._env or {}).keys())
                                 ))
@@ -476,21 +430,7 @@ class StdioMcpConnection:
                             os.chdir(orig_cwd)
                         except Exception:
                             pass
-            finally:
-                # restore original functions asap; keep the background tasks
-                try:
-                    asyncio.create_subprocess_exec = orig_create
-                except Exception:
-                    pass
-                try:
-                    if orig_subproc_create is not None:
-                        asyncio.subprocess.create_subprocess_exec = orig_subproc_create
-                except Exception:
-                    pass
-                try:
-                    subprocess.Popen = orig_popen
-                except Exception:
-                    pass
+                
                 # Optionally wrap read/write streams to log wire traffic for
                 # debugging. Enable by setting environment variable
                 # `MCP_STDIO_WIRE_LOG=1` when running tests.

--- a/backend/src/services/mcp/clients/ws_client.py
+++ b/backend/src/services/mcp/clients/ws_client.py
@@ -4,12 +4,17 @@ WebSocket MCP connection using the official MCP SDK.
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+import asyncio
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
 
 
 class WsMcpConnection:
     """WebSocket-based MCP client connection."""
 
-    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None, connect_timeout: float = 3.0) -> None:
+    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None, connect_timeout: float = 30.0) -> None:
         self._url = url
         self._headers = headers or {}
         self._connect_timeout = connect_timeout
@@ -27,16 +32,27 @@ class WsMcpConnection:
             except Exception:
                 from ..clients.websocket_client import websocket_client
 
+            logger.info(f"Connecting to WS MCP server: {self._url} (timeout={self._connect_timeout}s)")
             # Create websocket transport and session
             self._context = websocket_client(self._url, headers=self._headers or {})
-            read, write = await self._context.__aenter__()
+            
+            read, write = await asyncio.wait_for(self._context.__aenter__(), timeout=self._connect_timeout)
+            
             self._session = ClientSession(read, write)
-            await self._session.initialize()
+            await asyncio.wait_for(self._session.initialize(), timeout=self._connect_timeout)
             self._client = self._session
+            logger.info(f"Connected to WS MCP server: {self._url}")
+        except asyncio.TimeoutError:
+            self._session = None
+            self._client = None
+            logger.error(f"Timeout connecting to WS MCP server: {self._url}")
+            raise RuntimeError(f"Timeout connecting to {self._url} after {self._connect_timeout}s")
         except Exception as e:
             # Failed to connect or SDK not available
             self._session = None
             self._client = None
+            logger.error(f"Failed to start WS MCP connection to {self._url}: {e}")
+            logger.debug(traceback.format_exc())
             raise RuntimeError(f"Failed to start WS MCP connection: {e}") from e
 
     async def stop(self) -> None:

--- a/backend/tests/test_integrations_mcp.py
+++ b/backend/tests/test_integrations_mcp.py
@@ -10,7 +10,7 @@ def setup_dummy(monkeypatch, models=None):
         def __init__(self, model_name=None):
             self.model_name = model_name
 
-        def get_available_models(self):
+        async def get_available_models(self):
             return models if models is not None else [{"name": "dummy-model", "provider": "none", "size": 0, "modified_at": "now"}]
 
     # Patch the module path used by the running app (src.api.integrations_mcp)
@@ -18,7 +18,10 @@ def setup_dummy(monkeypatch, models=None):
         m = importlib.import_module("src.api.integrations_mcp")
     except Exception:
         m = importlib.import_module("backend.src.api.integrations_mcp")
-    monkeypatch.setattr(m, "get_ai_service", lambda model=None: DummyService(model))
+    
+    async def mock_get_ai_service(model=None):
+        return DummyService(model)
+    monkeypatch.setattr(m, "get_ai_service", mock_get_ai_service)
     return m
 
 

--- a/backend/tests/unit/test_mcp_remote_errors.py
+++ b/backend/tests/unit/test_mcp_remote_errors.py
@@ -1,0 +1,50 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+try:
+    from src.services.mcp.clients.sse_client import SseMcpConnection
+    from src.services.mcp.clients.ws_client import WsMcpConnection
+except ImportError:
+    from backend.src.services.mcp.clients.sse_client import SseMcpConnection
+    from backend.src.services.mcp.clients.ws_client import WsMcpConnection
+
+@pytest.mark.asyncio
+async def test_sse_timeout():
+    """Test that SseMcpConnection raises RuntimeError on timeout."""
+    with patch("mcp.client.streamable_http.streamablehttp_client") as mock_client:
+        # Mock context manager that hangs
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("mock timeout"))
+        mock_client.return_value = mock_ctx
+
+        conn = SseMcpConnection("http://localhost:8000/sse", timeout=0.1)
+        with pytest.raises(RuntimeError) as exc:
+            await conn.start()
+        assert "Timeout connecting" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_ws_timeout():
+    """Test that WsMcpConnection raises RuntimeError on timeout."""
+    with patch("mcp.client.websocket.websocket_client") as mock_ws:
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("mock timeout"))
+        mock_ws.return_value = mock_ctx
+
+        conn = WsMcpConnection("ws://localhost:8000/ws", connect_timeout=0.1)
+        with pytest.raises(RuntimeError) as exc:
+            await conn.start()
+        assert "Timeout connecting" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_sse_connection_error():
+    """Test that SseMcpConnection raises RuntimeError on generic error."""
+    with patch("mcp.client.streamable_http.streamablehttp_client") as mock_client:
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_client.return_value = mock_ctx
+
+        conn = SseMcpConnection("http://localhost:8000/sse")
+        with pytest.raises(RuntimeError) as exc:
+            await conn.start()
+        assert "Failed to start SSE MCP connection" in str(exc.value)
+        assert "Connection refused" in str(exc.value)

--- a/backend/tests/unit/test_mcp_security.py
+++ b/backend/tests/unit/test_mcp_security.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+try:
+    from src.api.integrations_mcp import router, _validate_stdio_command
+except ImportError:
+    from backend.src.api.integrations_mcp import router, _validate_stdio_command
+
+def test_validate_stdio_command_no_allowlist():
+    """If allowlist is not set, all commands should be allowed."""
+    with patch.dict(os.environ, {}, clear=True):
+        assert _validate_stdio_command("ls") is True
+        assert _validate_stdio_command("cat") is True
+
+def test_validate_stdio_command_allowlist():
+    """If allowlist is set, only permitted commands are allowed."""
+    with patch.dict(os.environ, {"MCP_STDIO_ALLOWLIST": "python,node,uv"}, clear=True):
+        assert _validate_stdio_command("python") is True
+        assert _validate_stdio_command("node") is True
+        assert _validate_stdio_command("uv") is True
+        assert _validate_stdio_command("bash") is False
+        assert _validate_stdio_command("rm") is False
+
+def test_validate_stdio_command_wildcard():
+    """If allowlist is *, all commands allowed."""
+    with patch.dict(os.environ, {"MCP_STDIO_ALLOWLIST": "*"}, clear=True):
+        assert _validate_stdio_command("rm") is True
+
+# Note: Testing the router directly requires a full app instance or careful patching of dependencies
+# like get_multi_mcp_client. For unit testing, testing the validation logic is sufficient.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -41,6 +41,12 @@ Rate limits / circuit breaker (env):
 - `MCP_CB_THRESHOLD` (default 3), `MCP_CB_COOLDOWN` (default 60)
 - `MCP_DOC_TTL` (default 86400 seconds)
 
+Security & Reliability (env):
+- `MCP_STDIO_ALLOWLIST`: A comma-separated list of allowed commands for Stdio transport (e.g., `python,node,uv`). Set to `*` to allow all (not recommended for production). If not set, all commands are allowed for backward compatibility.
+- `MCP_STDIO_START_TIMEOUT`: Timeout in seconds for local Stdio servers to start (default 30s).
+- `MCP_STDIO_WIRE_LOG`: Set to `1` to log raw wire traffic for Stdio connections to `backend/logs/`.
+- Connection Timeouts: Remote connections (SSE/WSS) now strictly honor timeouts (default 60s for SSE, 30s for WSS) and provide detailed error traces in the UI.
+
 ## API
 
 - `GET /api/integrations/mcp/servers` — list configured servers and discovery state

--- a/frontend/src/components/settings-panel.tsx
+++ b/frontend/src/components/settings-panel.tsx
@@ -53,6 +53,7 @@ const SettingsPanelInner: React.FC<SettingsPanelProps> = ({ onClose }) => {
   const [testFetchTool, setTestFetchTool] = useState<string>('http.get');
   const [testFetchTags, setTestFetchTags] = useState<string>('');
   const [testFetchResult, setTestFetchResult] = useState<{ snippet?: string; error?: string; structuredContent?: any } | null>(null);
+  const [testConnLog, setTestConnLog] = useState<string | null>(null);
 
   const isSettingsDirty = useMemo(
     () => JSON.stringify(localSettings) !== JSON.stringify(settings),
@@ -913,16 +914,28 @@ const SettingsPanelInner: React.FC<SettingsPanelProps> = ({ onClose }) => {
                 type="button"
                 onClick={async () => {
                   setTestConnLoading(true);
+                  setTestConnLog(null);
                   try {
                     const res = await testConnection(newServer);
                     if (res.ok) {
                       const toolNames = res.tools?.map((t: any) => t.name).join(', ') || 'none';
                       showToast({ variant: 'success', title: 'Connection Successful', description: `Found tools: ${toolNames}` });
+                      if ((res as any).log_tail) {
+                          setTestConnLog((res as any).log_tail);
+                      }
                     } else {
                       showToast({ variant: 'error', title: 'Connection Failed', description: res.error });
+                      const details = [
+                          res.error,
+                          (res as any).stderr,
+                          (res as any).error_trace,
+                          (res as any).log_tail
+                      ].filter(Boolean).join('\n\n---\n\n');
+                      setTestConnLog(details);
                     }
                   } catch (e: any) {
                     showToast({ variant: 'error', title: 'Connection Error', description: e.message });
+                    setTestConnLog(e.stack || e.message);
                   } finally {
                     setTestConnLoading(false);
                   }
@@ -933,6 +946,12 @@ const SettingsPanelInner: React.FC<SettingsPanelProps> = ({ onClose }) => {
                 {testConnLoading ? 'Testing...' : 'Test Connection'}
               </button>
             </div>
+            {testConnLog && (
+                <div className="mt-2 p-2 bg-muted/50 rounded text-xs border border-muted">
+                    <p className="font-semibold mb-1">Connection Log / Error Details:</p>
+                    <pre className="whitespace-pre-wrap overflow-auto max-h-40">{testConnLog}</pre>
+                </div>
+            )}
           </div>
 
           {/* Test Fetch via MCP */}


### PR DESCRIPTION
- Security: Implement MCP_STDIO_ALLOWLIST to restrict local command execution.
- Reliability: Use pathlib for robust path resolution in stdio client and server.
- Reliability: Refactor StdioMcpConnection to use scoped context manager for monkey-patching.
- Reliability: Add configurable timeouts for SSE and WebSocket connections.
- Observability: Expose detailed connection logs and error traces in the Frontend Settings UI.
- Reliability: Fix flaky init_model test by using BackgroundTasks properly.
- Tests: Add unit tests for security allowlist and remote connection timeouts.